### PR TITLE
Add missing date format

### DIFF
--- a/web/json_options.go
+++ b/web/json_options.go
@@ -57,6 +57,7 @@ func defaultJSONOptions() *jsonOptions {
 			{time.RubyDate, true},
 			{"2006-01-02T15:04:05.000Z0700", true},
 			{"2006-01-02 15:04:05", false},
+			{"01/02/2006 3:04:05 PM", false},
 			{time.ANSIC, false},
 			{"2006-01-02", false},
 			{"2006/01/02", false},


### PR DESCRIPTION
This PR adds a missing date format required by AAD. This should not be needed currently, so no need to create a specific release for this, but it seems like a good candidate for a default format.