### PR TITLE
Remove leading zeros from format

### DIFF
--- a/web/json_options.go
+++ b/web/json_options.go
@@ -57,7 +57,7 @@ func defaultJSONOptions() *jsonOptions {
 			{time.RubyDate, true},
 			{"2006-01-02T15:04:05.000Z0700", true},
 			{"2006-01-02 15:04:05", false},
-			{"01/02/2006 3:04:05 PM", false},
+			{"1/2/2006 3:04:05 PM", false},
 			{time.ANSIC, false},
 			{"2006-01-02", false},
 			{"2006/01/02", false},


### PR DESCRIPTION
This PR removes the leading zeros from the date time format to match with single digit months/days in the format they are returned from the AAD API.