### PR TITLE
[sc-13038] Skip null complex attribute values

### DIFF
--- a/server/internal/attribute_value.go
+++ b/server/internal/attribute_value.go
@@ -37,6 +37,9 @@ func validateAttributeValue(attribute *api_adapter_v1.AttributeConfig, value any
 
 	valid := false
 	switch value.(type) {
+	case []any:
+		value, _ := value.([]any)
+		valid = len(value) == 0 && attribute.List
 	case []bool:
 		valid = attribute.Type == api_adapter_v1.AttributeType_ATTRIBUTE_TYPE_BOOL && attribute.List
 	case []*bool:

--- a/server/internal/attribute_value_test.go
+++ b/server/internal/attribute_value_test.go
@@ -39,6 +39,29 @@ func TestValidateAttributeValue(t *testing.T) {
 			},
 			value: nil,
 		},
+		// Only an empty []interface{} list is allowed to be valid.
+		"empty_any_list": {
+			attribute: &api_adapter_v1.AttributeConfig{
+				Id:         "12268f03-f99d-476f-91cc-5fe3404e1654",
+				ExternalId: "something",
+				Type:       api_adapter_v1.AttributeType_ATTRIBUTE_TYPE_STRING,
+				List:       true,
+			},
+			value: []any{},
+		},
+		"non_empty_any_list": {
+			attribute: &api_adapter_v1.AttributeConfig{
+				Id:         "12268f03-f99d-476f-91cc-5fe3404e1654",
+				ExternalId: "something",
+				Type:       api_adapter_v1.AttributeType_ATTRIBUTE_TYPE_STRING,
+				List:       true,
+			},
+			value: []any{"1", 10},
+			wantAdapterErr: &api_adapter_v1.Error{
+				Message: "Adapter returned a value with invalid type []interface {} for attribute 12268f03-f99d-476f-91cc-5fe3404e1654 (something) with type ATTRIBUTE_TYPE_STRING (list=true). This is always indicative of a bug within the Adapter implementation.",
+				Code:    api_adapter_v1.ErrorCode_ERROR_CODE_INTERNAL,
+			},
+		},
 		"bool": {
 			attribute: &api_adapter_v1.AttributeConfig{
 				Id:         "12268f03-f99d-476f-91cc-5fe3404e1654",

--- a/server/internal/attribute_value_test.go
+++ b/server/internal/attribute_value_test.go
@@ -39,7 +39,7 @@ func TestValidateAttributeValue(t *testing.T) {
 			},
 			value: nil,
 		},
-		// Only an empty []interface{} list is allowed to be valid.
+		// Only an empty []interface{} list is allowed.
 		"empty_any_list": {
 			attribute: &api_adapter_v1.AttributeConfig{
 				Id:         "12268f03-f99d-476f-91cc-5fe3404e1654",

--- a/web/json_object.go
+++ b/web/json_object.go
@@ -62,7 +62,7 @@ func convertJSONObjectList(entity *framework.EntityConfig, objects []map[string]
 }
 
 // convertJSONObject parses and converts a JSON object received from the given
-//requested entity.
+// requested entity.
 func convertJSONObject(entity *framework.EntityConfig, object map[string]any, opts *jsonOptions) (framework.Object, error) {
 	parsedObject := make(framework.Object)
 
@@ -71,7 +71,7 @@ func convertJSONObject(entity *framework.EntityConfig, object map[string]any, op
 	// attributes and child objects, recursively.
 	var complexAttributes map[string]framework.Object
 	if opts.complexAttributeNameDelimiter != "" {
-		// Map of each single-valued complex attribute exernal ID to a
+		// Map of each single-valued complex attribute external ID to a
 		// pseudo entity config that can be used to parse that attribute.
 		complexAttributeFakeEntities := make(map[string]*framework.EntityConfig)
 
@@ -144,7 +144,13 @@ func convertJSONObject(entity *framework.EntityConfig, object map[string]any, op
 		complexAttributes = make(map[string]framework.Object, len(complexAttributeFakeEntities))
 
 		for localExternalId, fakeEntity := range complexAttributeFakeEntities {
-			complexValue, ok := object[localExternalId].(map[string]any)
+			// Do not parse null attribute values.
+			value, found := object[localExternalId]
+			if found && value == nil {
+				continue
+			}
+
+			complexValue, ok := value.(map[string]any)
 			if !ok {
 				return nil, fmt.Errorf("attribute %s is not a single-valued complex attribute", localExternalId)
 			}

--- a/web/json_object.go
+++ b/web/json_object.go
@@ -90,8 +90,8 @@ func convertJSONObject(entity *framework.EntityConfig, object map[string]any, op
 			localExternalId := externalIdComponents[0]
 			subExternalId := externalIdComponents[1]
 
-			_, found := object[localExternalId]
-			if !found {
+			rawValue, found := object[localExternalId]
+			if !found || rawValue == nil {
 				continue
 			}
 
@@ -144,13 +144,7 @@ func convertJSONObject(entity *framework.EntityConfig, object map[string]any, op
 		complexAttributes = make(map[string]framework.Object, len(complexAttributeFakeEntities))
 
 		for localExternalId, fakeEntity := range complexAttributeFakeEntities {
-			// Do not parse null attribute values.
-			value, found := object[localExternalId]
-			if found && value == nil {
-				continue
-			}
-
-			complexValue, ok := value.(map[string]any)
+			complexValue, ok := object[localExternalId].(map[string]any)
 			if !ok {
 				return nil, fmt.Errorf("attribute %s is not a single-valued complex attribute", localExternalId)
 			}

--- a/web/json_object_test.go
+++ b/web/json_object_test.go
@@ -455,6 +455,10 @@ func TestConvertJSONObject_Flattening(t *testing.T) {
 						Type:       framework.AttributeTypeString,
 					},
 					{
+						ExternalId: "a__a__b",
+						Type:       framework.AttributeTypeString,
+					},
+					{
 						ExternalId: "a__c__b",
 						Type:       framework.AttributeTypeString,
 					},
@@ -472,7 +476,8 @@ func TestConvertJSONObject_Flattening(t *testing.T) {
 				"a": {
 					"a": {
 						"a": "a__a__a value",
-						"b": "a__a__b value"
+						"b": "a__a__b value",
+						"c": "a__a__c value"
 					},
 					"b": "a__b value",
 					"c": {
@@ -492,11 +497,42 @@ func TestConvertJSONObject_Flattening(t *testing.T) {
 			opts: testJSONOptions,
 			wantObject: framework.Object{
 				"a__a__a": "a__a__a value",
+				"a__a__b": "a__a__b value",
 				"a__c__b": "a__c__b value",
 				"a__b":    "a__b value",
 				"c__a__a": "c__a__a value",
 			},
 			wantError: nil,
+		},
+		"null_complex_attribute": {
+			entity: &framework.EntityConfig{
+				ExternalId: "test",
+				Attributes: []*framework.AttributeConfig{
+					{
+						ExternalId: "a__b__c",
+						Type:       framework.AttributeTypeString,
+					},
+					{
+						ExternalId: "d__e",
+						Type:       framework.AttributeTypeString,
+					},
+					{
+						ExternalId: "d__e__f",
+						Type:       framework.AttributeTypeString,
+					},
+				},
+			},
+			// Suppose a__b is regularly a complex attribute, but in this case it is null. Same with d.
+			// We should ignore these attributes.
+			objectJSON: `{
+				"a": {
+					"b": null
+				},
+				"d": null
+			}`,
+			opts:       testJSONOptions,
+			wantObject: framework.Object{},
+			wantError:  nil,
 		},
 		"child_entities_in_complex_attributes": {
 			entity: &framework.EntityConfig{


### PR DESCRIPTION
More detailed examples of this bug can be found in the shortcut story: https://app.shortcut.com/sgnl/story/13038/adapter-framework-null-complex-attributes-should-be-skipped.

**Changes:**

- If a complex attribute is requested, e.g. `a__b__c`, but `a__b` is null, we should skip instead of throwing an error indicating that `b` is not a complex valued attribute.
- Accept an empty list `[]interface{}` as a valid value if `List: true` (another bug unrelated to this ticket).
- Add test cases.
- Minor typo fixes.