### PR TITLE
[sc-13038] Support empty `any` list attribute value

### DIFF
--- a/server/internal/attribute_value.go
+++ b/server/internal/attribute_value.go
@@ -106,6 +106,10 @@ func validateAttributeValue(attribute *api_adapter_v1.AttributeConfig, value any
 // Returns an error if the value's type is invalid.
 func getAttributeValues(value any) (list []*api_adapter_v1.AttributeValue, adapterErr *api_adapter_v1.Error) {
 	switch v := value.(type) {
+	case []any:
+		// validateAttributeValue only allows empty []any lists.
+		// So if the value has already been validated, we know it must be empty and we can return nil.
+		return nil, nil
 	case []bool:
 		return getAttributeListValues(v)
 	case []*bool:

--- a/server/internal/attribute_value.go
+++ b/server/internal/attribute_value.go
@@ -108,8 +108,9 @@ func getAttributeValues(value any) (list []*api_adapter_v1.AttributeValue, adapt
 	switch v := value.(type) {
 	case []any:
 		// validateAttributeValue only allows empty []any lists.
-		// So if the value has already been validated, we know it must be empty and we can return nil.
-		return nil, nil
+		// So if the value has already been validated, we know it must be empty and we return an empty list.
+		// If v is not empty, getAttributeListValues will call getAttributeValue which will return an error.
+		return getAttributeListValues(v)
 	case []bool:
 		return getAttributeListValues(v)
 	case []*bool:

--- a/server/internal/attribute_value_test.go
+++ b/server/internal/attribute_value_test.go
@@ -330,11 +330,16 @@ func TestGetAttributeValues(t *testing.T) {
 		},
 		"empty_any_list": {
 			value:                       []any{},
-			wantAttributeValuesListJSON: nil,
+			wantAttributeValuesListJSON: Ptr(`[]`),
 		},
 		"non_empty_any_list": {
 			value:                       []any{1234, "abcd"},
 			wantAttributeValuesListJSON: nil,
+			wantError: &api_adapter_v1.Error{
+				// The type is int because that's the first value in the list.
+				Message: "Adapter returned an attribute value with invalid type: int. This is always indicative of a bug within the Adapter implementation.",
+				Code:    api_adapter_v1.ErrorCode_ERROR_CODE_INTERNAL,
+			},
 		},
 		"bool": {
 			value:                       true,

--- a/server/internal/attribute_value_test.go
+++ b/server/internal/attribute_value_test.go
@@ -328,6 +328,14 @@ func TestGetAttributeValues(t *testing.T) {
 			value:                       []bool{},
 			wantAttributeValuesListJSON: Ptr(`[]`),
 		},
+		"empty_any_list": {
+			value:                       []any{},
+			wantAttributeValuesListJSON: nil,
+		},
+		"non_empty_any_list": {
+			value:                       []any{1234, "abcd"},
+			wantAttributeValuesListJSON: nil,
+		},
 		"bool": {
 			value:                       true,
 			wantAttributeValuesListJSON: Ptr(`[{"boolValue":true}]`),


### PR DESCRIPTION
**Changes:**

- The previous PR https://github.com/SGNL-ai/adapter-framework/pull/4 validates an empty `[]any` list as valid. However, the oversight was we did not add a case to parse the empty list after it's been marked valid.
- This PR adds a case for an empty list in `getAttributeValues`. Just return `nil`. 

**Testing:**

I have tested this locally by referencing my local `adapter-sgnl` repo to use my local `adapter-framework` instead of v0.3.0.