### PR TITLE
[sc-14313] Support UNIX timestamp to datetime conversion

### DIFF
--- a/web/json_options.go
+++ b/web/json_options.go
@@ -75,7 +75,7 @@ func defaultJSONOptions() *jsonOptions {
 			{"01-02-2006", false},
 			{"01/02/2006", false},
 			{"01/02/06", false},
-			{"sgnl-unix-ns-timestamp", false},
+			{"SGNLUnixSec", false}, // Unix timestamp representing seconds since 1970-01-01 00:00:00 UTC.
 		},
 		enableJSONPath:      false, // Disabled.
 		localTimeZoneOffset: 0,

--- a/web/json_options.go
+++ b/web/json_options.go
@@ -75,7 +75,7 @@ func defaultJSONOptions() *jsonOptions {
 			{"01-02-2006", false},
 			{"01/02/2006", false},
 			{"01/02/06", false},
-			{"sgnl-unix-ts", true},
+			{"sgnl-unix-ns-timestamp", false},
 		},
 		enableJSONPath:      false, // Disabled.
 		localTimeZoneOffset: 0,

--- a/web/json_options.go
+++ b/web/json_options.go
@@ -75,7 +75,7 @@ func defaultJSONOptions() *jsonOptions {
 			{"01-02-2006", false},
 			{"01/02/2006", false},
 			{"01/02/06", false},
-			{"sgnl-unix-ns", true},
+			{"sgnl-unix-ts", true},
 		},
 		enableJSONPath:      false, // Disabled.
 		localTimeZoneOffset: 0,

--- a/web/json_options.go
+++ b/web/json_options.go
@@ -75,6 +75,7 @@ func defaultJSONOptions() *jsonOptions {
 			{"01-02-2006", false},
 			{"01/02/2006", false},
 			{"01/02/06", false},
+			{"sgnl-unix-ns", true},
 		},
 		enableJSONPath:      false, // Disabled.
 		localTimeZoneOffset: 0,

--- a/web/json_options.go
+++ b/web/json_options.go
@@ -54,6 +54,10 @@ type DateTimeFormatWithTimeZone struct {
 	HasTimeZone bool
 }
 
+const (
+	SGNLUnixSec = "SGNLUnixSec"
+)
+
 func defaultJSONOptions() *jsonOptions {
 	return &jsonOptions{
 		complexAttributeNameDelimiter: "", // Disabled.
@@ -75,7 +79,7 @@ func defaultJSONOptions() *jsonOptions {
 			{"01-02-2006", false},
 			{"01/02/2006", false},
 			{"01/02/06", false},
-			{"SGNLUnixSec", false}, // Unix timestamp representing seconds since 1970-01-01 00:00:00 UTC.
+			{SGNLUnixSec, false}, // Unix timestamp representing seconds since 1970-01-01 00:00:00 UTC.
 		},
 		enableJSONPath:      false, // Disabled.
 		localTimeZoneOffset: 0,

--- a/web/json_value.go
+++ b/web/json_value.go
@@ -170,7 +170,7 @@ func convertJSONAttributeListValue[Element any](attribute *framework.AttributeCo
 // ParseDateTime parses a timestamp against a set of predefined formats.
 func ParseDateTime(dateTimeFormats []DateTimeFormatWithTimeZone, localTimeZoneOffset int, dateTimeStr string) (dateTime time.Time, err error) {
 	for _, format := range dateTimeFormats {
-		if format.Format == "sgnl-unix-ns-timestamp" {
+		if format.Format == "SGNLUnixSec" {
 			var unixTimestamp int64
 			unixTimestamp, err = strconv.ParseInt(dateTimeStr, 10, 64)
 			if err == nil {

--- a/web/json_value.go
+++ b/web/json_value.go
@@ -170,7 +170,7 @@ func convertJSONAttributeListValue[Element any](attribute *framework.AttributeCo
 // ParseDateTime parses a timestamp against a set of predefined formats.
 func ParseDateTime(dateTimeFormats []DateTimeFormatWithTimeZone, localTimeZoneOffset int, dateTimeStr string) (dateTime time.Time, err error) {
 	for _, format := range dateTimeFormats {
-		if format.Format == "sgnl-unix-ns" {
+		if format.Format == "sgnl-unix-ts" {
 			var unixTimestamp int64
 			unixTimestamp, err = strconv.ParseInt(dateTimeStr, 10, 64)
 			if err == nil {
@@ -203,7 +203,7 @@ func ParseDateTime(dateTimeFormats []DateTimeFormatWithTimeZone, localTimeZoneOf
 			}
 
 			// Convert unix timestamp to rfc3339 format
-			if format.Format == "sgnl-unix-ns" {
+			if format.Format == "sgnl-unix-ts" {
 				rfc3339Time := dateTime.Format(time.RFC3339)
 				dateTime, err = time.Parse(time.RFC3339, rfc3339Time)
 				if err != nil {

--- a/web/json_value.go
+++ b/web/json_value.go
@@ -170,7 +170,7 @@ func convertJSONAttributeListValue[Element any](attribute *framework.AttributeCo
 // ParseDateTime parses a timestamp against a set of predefined formats.
 func ParseDateTime(dateTimeFormats []DateTimeFormatWithTimeZone, localTimeZoneOffset int, dateTimeStr string) (dateTime time.Time, err error) {
 	for _, format := range dateTimeFormats {
-		if format.Format == "sgnl-unix-ts" {
+		if format.Format == "sgnl-unix-ns-timestamp" {
 			var unixTimestamp int64
 			unixTimestamp, err = strconv.ParseInt(dateTimeStr, 10, 64)
 			if err == nil {
@@ -200,15 +200,6 @@ func ParseDateTime(dateTimeFormats []DateTimeFormatWithTimeZone, localTimeZoneOf
 					dateTime.Nanosecond(),
 					loc,
 				)
-			}
-
-			// Convert unix timestamp to rfc3339 format
-			if format.Format == "sgnl-unix-ts" {
-				rfc3339Time := dateTime.Format(time.RFC3339)
-				dateTime, err = time.Parse(time.RFC3339, rfc3339Time)
-				if err != nil {
-					err = fmt.Errorf("panic: unix post conversion to rfc3339 failed. dateTimeStr: %s, parse error: %v", dateTimeStr, err)
-				}
 			}
 
 			return

--- a/web/json_value_test.go
+++ b/web/json_value_test.go
@@ -95,7 +95,7 @@ func TestConvertJSONAttributeValue(t *testing.T) {
 			},
 			valueJSON: `"1706041056"`,
 
-			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"sgnl-unix-ns-timestamp", false}}},
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"SGNLUnixSec", false}}},
 			wantValue: MustParseTime(t, "2024-01-23T20:17:36Z"),
 		},
 		"valid_unix_missing_option": {
@@ -115,7 +115,7 @@ func TestConvertJSONAttributeValue(t *testing.T) {
 			},
 			valueJSON: `"+1706041056"`,
 
-			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"sgnl-unix-ns-timestamp", false}}},
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"SGNLUnixSec", false}}},
 			wantValue: MustParseTime(t, "2024-01-23T20:17:36Z"),
 		},
 		"invalid_unix_timestamp": {
@@ -125,7 +125,7 @@ func TestConvertJSONAttributeValue(t *testing.T) {
 			},
 			valueJSON: `"17060invalid6"`,
 
-			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"sgnl-unix-ns-timestamp", false}}},
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"SGNLUnixSec", false}}},
 			wantError: errors.New("attribute a cannot be parsed into a date-time value: failed to parse date-time value: 17060invalid6"),
 		},
 		"unix_timestamp_int64_overflow": {
@@ -135,7 +135,7 @@ func TestConvertJSONAttributeValue(t *testing.T) {
 			},
 			valueJSON: `"9999999999999999999999999999999999999999"`,
 
-			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"sgnl-unix-ns-timestamp", false}}},
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"SGNLUnixSec", false}}},
 			wantError: errors.New("attribute a cannot be parsed into a date-time value: failed to parse date-time value: 9999999999999999999999999999999999999999"),
 		},
 		"neg_unix": {
@@ -145,7 +145,7 @@ func TestConvertJSONAttributeValue(t *testing.T) {
 			},
 			valueJSON: `"-1706041056"`,
 
-			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"sgnl-unix-ns-timestamp", false}}},
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"SGNLUnixSec", false}}},
 			wantValue: MustParseTime(t, "1915-12-10T03:42:24Z"),
 		},
 		"unix_with_local_timezone_offset": {
@@ -155,7 +155,7 @@ func TestConvertJSONAttributeValue(t *testing.T) {
 			},
 			valueJSON: `"1706041056"`,
 
-			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"sgnl-unix-ns-timestamp", false}}, localTimeZoneOffset: 10 * 60 * 60},
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"SGNLUnixSec", false}}, localTimeZoneOffset: 10 * 60 * 60},
 			wantValue: MustParseTime(t, "2024-01-23T20:17:36+10:00"),
 		},
 		"unix_with_negative_time_zone_offset": {
@@ -165,7 +165,7 @@ func TestConvertJSONAttributeValue(t *testing.T) {
 			},
 			valueJSON: `"1706041056"`,
 
-			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"sgnl-unix-ns-timestamp", false}}, localTimeZoneOffset: -10 * 60 * 60},
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"SGNLUnixSec", false}}, localTimeZoneOffset: -10 * 60 * 60},
 			wantValue: MustParseTime(t, "2024-01-23T20:17:36-10:00"),
 		},
 		"datetime": {

--- a/web/json_value_test.go
+++ b/web/json_value_test.go
@@ -95,8 +95,48 @@ func TestConvertJSONAttributeValue(t *testing.T) {
 			},
 			valueJSON: `"1706041056"`,
 
-			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"sgnl-unix-ts", false}, {"2006-01-02", false}}},
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"sgnl-unix-ns-timestamp", false}}},
 			wantValue: MustParseTime(t, "2024-01-23T20:17:36Z"),
+		},
+		"valid_unix_missing_option": {
+			attribute: &framework.AttributeConfig{
+				ExternalId: "a",
+				Type:       framework.AttributeTypeDateTime,
+			},
+			valueJSON: `"1706041056"`,
+
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{time.RFC3339, true}}},
+			wantError: errors.New("attribute a cannot be parsed into a date-time value: failed to parse date-time value: 1706041056"),
+		},
+		"unix_prefixed_with_+": {
+			attribute: &framework.AttributeConfig{
+				ExternalId: "a",
+				Type:       framework.AttributeTypeDateTime,
+			},
+			valueJSON: `"+1706041056"`,
+
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"sgnl-unix-ns-timestamp", false}}},
+			wantValue: MustParseTime(t, "2024-01-23T20:17:36Z"),
+		},
+		"invalid_unix_timestamp": {
+			attribute: &framework.AttributeConfig{
+				ExternalId: "a",
+				Type:       framework.AttributeTypeDateTime,
+			},
+			valueJSON: `"17060invalid6"`,
+
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"sgnl-unix-ns-timestamp", false}}},
+			wantError: errors.New("attribute a cannot be parsed into a date-time value: failed to parse date-time value: 17060invalid6"),
+		},
+		"unix_timestamp_int64_overflow": {
+			attribute: &framework.AttributeConfig{
+				ExternalId: "a",
+				Type:       framework.AttributeTypeDateTime,
+			},
+			valueJSON: `"9999999999999999999999999999999999999999"`,
+
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"sgnl-unix-ns-timestamp", false}}},
+			wantError: errors.New("attribute a cannot be parsed into a date-time value: failed to parse date-time value: 9999999999999999999999999999999999999999"),
 		},
 		"neg_unix": {
 			attribute: &framework.AttributeConfig{
@@ -105,28 +145,28 @@ func TestConvertJSONAttributeValue(t *testing.T) {
 			},
 			valueJSON: `"-1706041056"`,
 
-			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"sgnl-unix-ts", false}, {"2006-01-02", false}}},
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"sgnl-unix-ns-timestamp", false}}},
 			wantValue: MustParseTime(t, "1915-12-10T03:42:24Z"),
 		},
-		"unix_with_tz_offset": {
+		"unix_with_local_timezone_offset": {
 			attribute: &framework.AttributeConfig{
 				ExternalId: "a",
 				Type:       framework.AttributeTypeDateTime,
 			},
 			valueJSON: `"1706041056"`,
 
-			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"sgnl-unix-ts", true}, {"2006-01-02", false}}, localTimeZoneOffset: 60 * 60},
-			wantValue: MustParseTime(t, "2024-01-23T20:17:36Z"),
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"sgnl-unix-ns-timestamp", false}}, localTimeZoneOffset: 10 * 60 * 60},
+			wantValue: MustParseTime(t, "2024-01-23T20:17:36+10:00"),
 		},
-		"unix_with_neg_tz_offset": {
+		"unix_with_negative_time_zone_offset": {
 			attribute: &framework.AttributeConfig{
 				ExternalId: "a",
 				Type:       framework.AttributeTypeDateTime,
 			},
 			valueJSON: `"1706041056"`,
 
-			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"sgnl-unix-ts", true}, {"2006-01-02", false}}, localTimeZoneOffset: -10 * 60 * 60},
-			wantValue: MustParseTime(t, "2024-01-23T20:17:36Z"),
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"sgnl-unix-ns-timestamp", false}}, localTimeZoneOffset: -10 * 60 * 60},
+			wantValue: MustParseTime(t, "2024-01-23T20:17:36-10:00"),
 		},
 		"datetime": {
 			attribute: &framework.AttributeConfig{

--- a/web/json_value_test.go
+++ b/web/json_value_test.go
@@ -95,7 +95,7 @@ func TestConvertJSONAttributeValue(t *testing.T) {
 			},
 			valueJSON: `"1706041056"`,
 
-			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"sgnl-unix-ns", false}, {"2006-01-02", false}}},
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"sgnl-unix-ts", false}, {"2006-01-02", false}}},
 			wantValue: MustParseTime(t, "2024-01-23T20:17:36Z"),
 		},
 		"neg_unix": {
@@ -105,7 +105,7 @@ func TestConvertJSONAttributeValue(t *testing.T) {
 			},
 			valueJSON: `"-1706041056"`,
 
-			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"sgnl-unix-ns", false}, {"2006-01-02", false}}},
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"sgnl-unix-ts", false}, {"2006-01-02", false}}},
 			wantValue: MustParseTime(t, "1915-12-10T03:42:24Z"),
 		},
 		"unix_with_tz_offset": {
@@ -115,7 +115,7 @@ func TestConvertJSONAttributeValue(t *testing.T) {
 			},
 			valueJSON: `"1706041056"`,
 
-			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"sgnl-unix-ns", true}, {"2006-01-02", false}}, localTimeZoneOffset: 60 * 60},
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"sgnl-unix-ts", true}, {"2006-01-02", false}}, localTimeZoneOffset: 60 * 60},
 			wantValue: MustParseTime(t, "2024-01-23T20:17:36Z"),
 		},
 		"unix_with_neg_tz_offset": {
@@ -125,7 +125,7 @@ func TestConvertJSONAttributeValue(t *testing.T) {
 			},
 			valueJSON: `"1706041056"`,
 
-			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"sgnl-unix-ns", true}, {"2006-01-02", false}}, localTimeZoneOffset: -10 * 60 * 60},
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"sgnl-unix-ts", true}, {"2006-01-02", false}}, localTimeZoneOffset: -10 * 60 * 60},
 			wantValue: MustParseTime(t, "2024-01-23T20:17:36Z"),
 		},
 		"datetime": {

--- a/web/json_value_test.go
+++ b/web/json_value_test.go
@@ -88,6 +88,46 @@ func TestConvertJSONAttributeValue(t *testing.T) {
 			valueJSON: `[true, 0, "true"]`,
 			wantValue: []bool{true, false, true},
 		},
+		"unix": {
+			attribute: &framework.AttributeConfig{
+				ExternalId: "a",
+				Type:       framework.AttributeTypeDateTime,
+			},
+			valueJSON: `"1706041056"`,
+
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"sgnl-unix-ns", false}, {"2006-01-02", false}}},
+			wantValue: MustParseTime(t, "2024-01-23T20:17:36Z"),
+		},
+		"neg_unix": {
+			attribute: &framework.AttributeConfig{
+				ExternalId: "a",
+				Type:       framework.AttributeTypeDateTime,
+			},
+			valueJSON: `"-1706041056"`,
+
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"sgnl-unix-ns", false}, {"2006-01-02", false}}},
+			wantValue: MustParseTime(t, "1915-12-10T03:42:24Z"),
+		},
+		"unix_with_tz_offset": {
+			attribute: &framework.AttributeConfig{
+				ExternalId: "a",
+				Type:       framework.AttributeTypeDateTime,
+			},
+			valueJSON: `"1706041056"`,
+
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"sgnl-unix-ns", true}, {"2006-01-02", false}}, localTimeZoneOffset: 60 * 60},
+			wantValue: MustParseTime(t, "2024-01-23T20:17:36Z"),
+		},
+		"unix_with_neg_tz_offset": {
+			attribute: &framework.AttributeConfig{
+				ExternalId: "a",
+				Type:       framework.AttributeTypeDateTime,
+			},
+			valueJSON: `"1706041056"`,
+
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"sgnl-unix-ns", true}, {"2006-01-02", false}}, localTimeZoneOffset: -10 * 60 * 60},
+			wantValue: MustParseTime(t, "2024-01-23T20:17:36Z"),
+		},
 		"datetime": {
 			attribute: &framework.AttributeConfig{
 				ExternalId: "a",


### PR DESCRIPTION
This conversion is necessary to support attributes that are represented as UNIX timestamps from the Duo Adapter responses.

[Story](https://app.shortcut.com/sgnl/story/20157/productionize-duo-as-an-sor)
