### PR TITLE
[sc-14313] Add support for parsing UNIX timestamp represented as a number

### DIFF
--- a/web/json_value.go
+++ b/web/json_value.go
@@ -82,14 +82,20 @@ func convertJSONAttributeValue(attribute *framework.AttributeConfig, value any, 
 		return boolValue, nil
 
 	case framework.AttributeTypeDateTime:
-		v, ok := value.(string)
-		if !ok {
-			return nil, fmt.Errorf("attribute %s cannot be parsed into a string date-time value", attribute.ExternalId)
+		var dateTimeStr string
+		switch v := value.(type) {
+		case string:
+			dateTimeStr = v
+		case float64:
+			dateTimeStr = fmt.Sprintf("%f", v)
+		default:
+			return nil, fmt.Errorf("attribute %s cannot be parsed into a string date-time value because its type is %T, not string or float64", attribute.ExternalId, v)
 		}
-		if v == "" {
+
+		if dateTimeStr == "" {
 			return nil, nil
 		}
-		t, err := ParseDateTime(opts.dateTimeFormats, opts.localTimeZoneOffset, v)
+		t, err := ParseDateTime(opts.dateTimeFormats, opts.localTimeZoneOffset, dateTimeStr)
 		if err != nil {
 			return nil, fmt.Errorf("attribute %s cannot be parsed into a date-time value: %w", attribute.ExternalId, err)
 		}

--- a/web/json_value.go
+++ b/web/json_value.go
@@ -88,8 +88,13 @@ func convertJSONAttributeValue(attribute *framework.AttributeConfig, value any, 
 		case string:
 			dateTimeStr = v
 		case float64:
+			// make sure float is in int64 range
 			if v > float64(math.MaxInt64) || v < float64(math.MinInt64) {
 				return nil, fmt.Errorf("attribute %s cannot be parsed into a string date-time value because the float64 value is out of the int64 range", attribute.ExternalId)
+			}
+			// make sure float only has 0 decimals (e.g. 123.00000)
+			if float64(int(v)) != v {
+				return nil, fmt.Errorf("attribute %s cannot be parsed into a string date-time value because the float64 value is not an exact integer", attribute.ExternalId)
 			}
 			dateTimeStr = fmt.Sprintf("%d", int(v))
 		default:

--- a/web/json_value.go
+++ b/web/json_value.go
@@ -16,6 +16,7 @@ package web
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -87,7 +88,10 @@ func convertJSONAttributeValue(attribute *framework.AttributeConfig, value any, 
 		case string:
 			dateTimeStr = v
 		case float64:
-			dateTimeStr = fmt.Sprintf("%f", v)
+			if v > float64(math.MaxInt64) || v < float64(math.MinInt64) {
+				return nil, fmt.Errorf("attribute %s cannot be parsed into a string date-time value because the float64 value is out of the int64 range", attribute.ExternalId)
+			}
+			dateTimeStr = fmt.Sprintf("%d", int(v))
 		default:
 			return nil, fmt.Errorf("attribute %s cannot be parsed into a string date-time value because its type is %T, not string or float64", attribute.ExternalId, v)
 		}

--- a/web/json_value.go
+++ b/web/json_value.go
@@ -93,7 +93,7 @@ func convertJSONAttributeValue(attribute *framework.AttributeConfig, value any, 
 				return nil, fmt.Errorf("attribute %s cannot be parsed into a date-time value as the value is out of the valid range", attribute.ExternalId)
 			}
 			// make sure float only has 0 decimals (e.g. 123.00000)
-			if float64(int(v)) != v {
+			if float64(int64(v)) != v {
 				return nil, fmt.Errorf("attribute %s cannot be parsed into a date-time because the value is not an integer", attribute.ExternalId)
 			}
 			dateTimeStr = fmt.Sprintf("%d", int64(v))

--- a/web/json_value.go
+++ b/web/json_value.go
@@ -88,17 +88,17 @@ func convertJSONAttributeValue(attribute *framework.AttributeConfig, value any, 
 		case string:
 			dateTimeStr = v
 		case float64:
-			// make sure float is in int64 range
+			// make sure the value is in int64 range
 			if v > float64(math.MaxInt64) || v < float64(math.MinInt64) {
-				return nil, fmt.Errorf("attribute %s cannot be parsed into a string date-time value because the float64 value is out of the int64 range", attribute.ExternalId)
+				return nil, fmt.Errorf("attribute %s cannot be parsed into a date-time value as the value is out of the valid range", attribute.ExternalId)
 			}
 			// make sure float only has 0 decimals (e.g. 123.00000)
 			if float64(int(v)) != v {
-				return nil, fmt.Errorf("attribute %s cannot be parsed into a string date-time value because the float64 value is not an exact integer", attribute.ExternalId)
+				return nil, fmt.Errorf("attribute %s cannot be parsed into a date-time because the value is not an integer", attribute.ExternalId)
 			}
-			dateTimeStr = fmt.Sprintf("%d", int(v))
+			dateTimeStr = fmt.Sprintf("%d", int64(v))
 		default:
-			return nil, fmt.Errorf("attribute %s cannot be parsed into a string date-time value because its type is %T, not string or float64", attribute.ExternalId, v)
+			return nil, fmt.Errorf("attribute %s cannot be parsed into a date-time due to invalid type: %T", attribute.ExternalId, v)
 		}
 
 		if dateTimeStr == "" {

--- a/web/json_value_test.go
+++ b/web/json_value_test.go
@@ -93,7 +93,7 @@ func TestConvertJSONAttributeValue(t *testing.T) {
 				ExternalId: "a",
 				Type:       framework.AttributeTypeDateTime,
 			},
-			valueJSON: `"1706041056"`,
+			valueJSON: `1706041056.0`,
 
 			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"SGNLUnixSec", false}}},
 			wantValue: MustParseTime(t, "2024-01-23T20:17:36Z"),
@@ -103,7 +103,7 @@ func TestConvertJSONAttributeValue(t *testing.T) {
 				ExternalId: "a",
 				Type:       framework.AttributeTypeDateTime,
 			},
-			valueJSON: `"1706041056"`,
+			valueJSON: `1706041056.0`,
 
 			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{time.RFC3339, true}}},
 			wantError: errors.New("attribute a cannot be parsed into a date-time value: failed to parse date-time value: 1706041056"),
@@ -114,7 +114,6 @@ func TestConvertJSONAttributeValue(t *testing.T) {
 				Type:       framework.AttributeTypeDateTime,
 			},
 			valueJSON: `"+1706041056"`,
-
 			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"SGNLUnixSec", false}}},
 			wantValue: MustParseTime(t, "2024-01-23T20:17:36Z"),
 		},
@@ -133,17 +132,17 @@ func TestConvertJSONAttributeValue(t *testing.T) {
 				ExternalId: "a",
 				Type:       framework.AttributeTypeDateTime,
 			},
-			valueJSON: `"9999999999999999999999999999999999999999"`,
+			valueJSON: `9999999999999999999999999999999999999999.0`,
 
 			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"SGNLUnixSec", false}}},
-			wantError: errors.New("attribute a cannot be parsed into a date-time value: failed to parse date-time value: 9999999999999999999999999999999999999999"),
+			wantError: errors.New("attribute a cannot be parsed into a string date-time value because the float64 value is out of the int64 range"),
 		},
 		"neg_unix": {
 			attribute: &framework.AttributeConfig{
 				ExternalId: "a",
 				Type:       framework.AttributeTypeDateTime,
 			},
-			valueJSON: `"-1706041056"`,
+			valueJSON: `-1706041056.0`,
 
 			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"SGNLUnixSec", false}}},
 			wantValue: MustParseTime(t, "1915-12-10T03:42:24Z"),
@@ -153,7 +152,7 @@ func TestConvertJSONAttributeValue(t *testing.T) {
 				ExternalId: "a",
 				Type:       framework.AttributeTypeDateTime,
 			},
-			valueJSON: `"1706041056"`,
+			valueJSON: `1706041056.0`,
 
 			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"SGNLUnixSec", false}}, localTimeZoneOffset: 10 * 60 * 60},
 			wantValue: MustParseTime(t, "2024-01-23T20:17:36+10:00"),
@@ -163,7 +162,7 @@ func TestConvertJSONAttributeValue(t *testing.T) {
 				ExternalId: "a",
 				Type:       framework.AttributeTypeDateTime,
 			},
-			valueJSON: `"1706041056"`,
+			valueJSON: `1706041056.0`,
 
 			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"SGNLUnixSec", false}}, localTimeZoneOffset: -10 * 60 * 60},
 			wantValue: MustParseTime(t, "2024-01-23T20:17:36-10:00"),

--- a/web/json_value_test.go
+++ b/web/json_value_test.go
@@ -93,7 +93,7 @@ func TestConvertJSONAttributeValue(t *testing.T) {
 				ExternalId: "a",
 				Type:       framework.AttributeTypeDateTime,
 			},
-			valueJSON: `1706041056.0`,
+			valueJSON: `1706041056`,
 
 			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"SGNLUnixSec", false}}},
 			wantValue: MustParseTime(t, "2024-01-23T20:17:36Z"),
@@ -103,7 +103,7 @@ func TestConvertJSONAttributeValue(t *testing.T) {
 				ExternalId: "a",
 				Type:       framework.AttributeTypeDateTime,
 			},
-			valueJSON: `1706041056.0`,
+			valueJSON: `1706041056`,
 
 			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{time.RFC3339, true}}},
 			wantError: errors.New("attribute a cannot be parsed into a date-time value: failed to parse date-time value: 1706041056"),
@@ -132,17 +132,17 @@ func TestConvertJSONAttributeValue(t *testing.T) {
 				ExternalId: "a",
 				Type:       framework.AttributeTypeDateTime,
 			},
-			valueJSON: `9999999999999999999999999999999999999999.0`,
+			valueJSON: `9999999999999999999999999999999999999999`,
 
 			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"SGNLUnixSec", false}}},
-			wantError: errors.New("attribute a cannot be parsed into a string date-time value because the float64 value is out of the int64 range"),
+			wantError: errors.New("attribute a cannot be parsed into a date-time value as the value is out of the valid range"),
 		},
 		"neg_unix": {
 			attribute: &framework.AttributeConfig{
 				ExternalId: "a",
 				Type:       framework.AttributeTypeDateTime,
 			},
-			valueJSON: `-1706041056.0`,
+			valueJSON: `-1706041056`,
 
 			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"SGNLUnixSec", false}}},
 			wantValue: MustParseTime(t, "1915-12-10T03:42:24Z"),
@@ -152,7 +152,7 @@ func TestConvertJSONAttributeValue(t *testing.T) {
 				ExternalId: "a",
 				Type:       framework.AttributeTypeDateTime,
 			},
-			valueJSON: `1706041056.0`,
+			valueJSON: `1706041056`,
 
 			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"SGNLUnixSec", false}}, localTimeZoneOffset: 10 * 60 * 60},
 			wantValue: MustParseTime(t, "2024-01-23T20:17:36+10:00"),
@@ -162,7 +162,7 @@ func TestConvertJSONAttributeValue(t *testing.T) {
 				ExternalId: "a",
 				Type:       framework.AttributeTypeDateTime,
 			},
-			valueJSON: `1706041056.0`,
+			valueJSON: `1706041056`,
 
 			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"SGNLUnixSec", false}}, localTimeZoneOffset: -10 * 60 * 60},
 			wantValue: MustParseTime(t, "2024-01-23T20:17:36-10:00"),

--- a/web/json_value_test.go
+++ b/web/json_value_test.go
@@ -127,6 +127,16 @@ func TestConvertJSONAttributeValue(t *testing.T) {
 			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"SGNLUnixSec", false}}},
 			wantError: errors.New("attribute a cannot be parsed into a date-time value: failed to parse date-time value: 17060invalid6"),
 		},
+		"invalid_float_unix_timestamp": {
+			attribute: &framework.AttributeConfig{
+				ExternalId: "a",
+				Type:       framework.AttributeTypeDateTime,
+			},
+			valueJSON: `1706041056.005`,
+
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"SGNLUnixSec", false}}},
+			wantError: errors.New("attribute a cannot be parsed into a date-time because the value is not an integer"),
+		},
 		"unix_timestamp_int64_overflow": {
 			attribute: &framework.AttributeConfig{
 				ExternalId: "a",


### PR DESCRIPTION
In v0.8.0, support for unix timestamp conversion to datetime was added. However, this was failing because the datetime conversion only was accepting string values. 

[sc-20157](https://app.shortcut.com/sgnl/story/20157/productionize-duo-as-an-sor)