### PR TITLE
[sc-22645] Add support for generalized time format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 )
 
 require (
+	github.com/go-asn1-ber/asn1-ber v1.5.6 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	golang.org/x/net v0.23.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/PaesslerAG/jsonpath v0.1.1 h1:c1/AToHQMVsduPAa4Vh6xp2U0evy4t8SWp8imEs
 github.com/PaesslerAG/jsonpath v0.1.1/go.mod h1:lVboNxFGal/VwW6d9JzIy56bUsYAP6tH/x80vjnCseY=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
+github.com/go-asn1-ber/asn1-ber v1.5.6 h1:CYsqysemXfEaQbyrLJmdsCRuufHoLa3P/gGWGl5TDrM=
+github.com/go-asn1-ber/asn1-ber v1.5.6/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=

--- a/web/json_options.go
+++ b/web/json_options.go
@@ -55,7 +55,8 @@ type DateTimeFormatWithTimeZone struct {
 }
 
 const (
-	SGNLUnixSec = "SGNLUnixSec"
+	SGNLUnixSec         = "SGNLUnixSec"
+	SGNLGeneralizedTime = "SGNLGeneralizedTime"
 )
 
 func defaultJSONOptions() *jsonOptions {
@@ -79,7 +80,8 @@ func defaultJSONOptions() *jsonOptions {
 			{"01-02-2006", false},
 			{"01/02/2006", false},
 			{"01/02/06", false},
-			{SGNLUnixSec, false}, // Unix timestamp representing seconds since 1970-01-01 00:00:00 UTC.
+			{SGNLUnixSec, false},        // Unix timestamp representing seconds since 1970-01-01 00:00:00 UTC.
+			{SGNLGeneralizedTime, true}, // https://datatracker.ietf.org/doc/html/rfc4517#section-3.3.13  Generalized Time
 		},
 		enableJSONPath:      false, // Disabled.
 		localTimeZoneOffset: 0,

--- a/web/json_value.go
+++ b/web/json_value.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	ber "github.com/go-asn1-ber/asn1-ber"
 	framework "github.com/sgnl-ai/adapter-framework"
 )
 
@@ -191,6 +192,8 @@ func ParseDateTime(dateTimeFormats []DateTimeFormatWithTimeZone, localTimeZoneOf
 			if err == nil {
 				dateTime = time.Unix(unixTimestamp, 0)
 			}
+		} else if format.Format == SGNLGeneralizedTime {
+			dateTime, err = ber.ParseGeneralizedTime([]byte(dateTimeStr))
 		} else {
 			dateTime, err = time.Parse(format.Format, dateTimeStr)
 		}

--- a/web/json_value_test.go
+++ b/web/json_value_test.go
@@ -177,6 +177,108 @@ func TestConvertJSONAttributeValue(t *testing.T) {
 			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"SGNLUnixSec", false}}, localTimeZoneOffset: -10 * 60 * 60},
 			wantValue: MustParseTime(t, "2024-01-23T20:17:36-10:00"),
 		},
+		"generalized_with_seconds_and_z": {
+			attribute: &framework.AttributeConfig{
+				ExternalId: "a",
+				Type:       framework.AttributeTypeDateTime,
+			},
+			valueJSON: `"20240222190527Z"`,
+
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{SGNLGeneralizedTime, true}}},
+			wantValue: time.Date(2024, time.Month(2), 22, 19, 5, 27, 0, time.UTC),
+		},
+		"generalized_with_minutes_and_z": {
+			attribute: &framework.AttributeConfig{
+				ExternalId: "a",
+				Type:       framework.AttributeTypeDateTime,
+			},
+			valueJSON: `"202402221905Z"`,
+
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{SGNLGeneralizedTime, true}}},
+			wantValue: time.Date(2024, time.Month(2), 22, 19, 5, 0, 0, time.UTC),
+		},
+		"generalized_with_hours_and_z": {
+			attribute: &framework.AttributeConfig{
+				ExternalId: "a",
+				Type:       framework.AttributeTypeDateTime,
+			},
+			valueJSON: `"2024022219Z"`,
+
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{SGNLGeneralizedTime, true}}},
+			wantValue: time.Date(2024, time.Month(2), 22, 19, 0, 0, 0, time.UTC),
+		},
+		"generalized_with_fractional_minutes_and_z": {
+			attribute: &framework.AttributeConfig{
+				ExternalId: "a",
+				Type:       framework.AttributeTypeDateTime,
+			},
+			valueJSON: `"2024022219.25Z"`,
+
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{SGNLGeneralizedTime, true}}},
+			wantValue: time.Date(2024, time.Month(2), 22, 19, 15, 0, 0, time.UTC),
+		},
+		"generalized_with_fractional_seconds_and_z": {
+			attribute: &framework.AttributeConfig{
+				ExternalId: "a",
+				Type:       framework.AttributeTypeDateTime,
+			},
+			valueJSON: `"202402221905.25Z"`,
+
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{SGNLGeneralizedTime, true}}},
+			wantValue: time.Date(2024, time.Month(2), 22, 19, 5, 15, 0, time.UTC),
+		},
+		"generalized_with_timezone_offset": {
+			attribute: &framework.AttributeConfig{
+				ExternalId: "a",
+				Type:       framework.AttributeTypeDateTime,
+			},
+			valueJSON: `"20240222190525-0100"`,
+
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{SGNLGeneralizedTime, true}}},
+			wantValue: time.Date(2024, time.Month(2), 22, 19, 5, 25, 0, time.FixedZone("", -3600)),
+		},
+
+		"generalized_with_positive_timezone_offset": {
+			attribute: &framework.AttributeConfig{
+				ExternalId: "a",
+				Type:       framework.AttributeTypeDateTime,
+			},
+			valueJSON: `"20240222190525+0100"`,
+
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{SGNLGeneralizedTime, true}}},
+			wantValue: time.Date(2024, time.Month(2), 22, 19, 5, 25, 0, time.FixedZone("", 3600)),
+		},
+		"generalized_with_short_positive_timezone_offset": {
+			attribute: &framework.AttributeConfig{
+				ExternalId: "a",
+				Type:       framework.AttributeTypeDateTime,
+			},
+			valueJSON: `"20240222190525+0100"`,
+
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{SGNLGeneralizedTime, true}}},
+			wantValue: time.Date(2024, time.Month(2), 22, 19, 5, 25, 0, time.FixedZone("", 3600)),
+		},
+
+		"generalized_with_milliseconds_and_z": {
+			attribute: &framework.AttributeConfig{
+				ExternalId: "a",
+				Type:       framework.AttributeTypeDateTime,
+			},
+			valueJSON: `"20240222190527.123Z"`,
+
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{SGNLGeneralizedTime, true}}},
+			wantValue: time.Date(2024, time.Month(2), 22, 19, 5, 27, 123*1000*1000, time.UTC),
+		},
+		"generalized_with_timezone_offset_and_z": {
+			attribute: &framework.AttributeConfig{
+				ExternalId: "a",
+				Type:       framework.AttributeTypeDateTime,
+			},
+			valueJSON: `"2024022219-0100"`,
+
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{SGNLGeneralizedTime, true}}},
+			wantValue: time.Date(2024, time.Month(2), 22, 19, 0, 0, 0, time.FixedZone("", -3600)),
+		},
 		"datetime": {
 			attribute: &framework.AttributeConfig{
 				ExternalId: "a",


### PR DESCRIPTION
This PR adds support for parsing the [Generalized time](https://datatracker.ietf.org/doc/html/rfc4517#section-3.3.13) format in the framework.


**Shortcut story**

<!--- Please provide the linked story of this PR. -->

[sc-22645](https://app.shortcut.com/sgnl/story/22645/sor-support-active-directory-as-a-system-of-record)
