### PR TITLE
[sc-30479] Add support for parsing unix timestamp in milliseconds

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"sort"
 	"testing"
 	"time"
 
@@ -172,6 +173,8 @@ func TestRegisterAdapter(t *testing.T) {
 	for k := range s.AdapterGetPageFuncs {
 		registeredDatasources = append(registeredDatasources, k)
 	}
+
+	sort.Strings(registeredDatasources)
 
 	want := []string{"Mock-1.0.1", "Mock-1.0.2"}
 

--- a/web/json_options.go
+++ b/web/json_options.go
@@ -81,11 +81,7 @@ func defaultJSONOptions() *jsonOptions {
 			{"01-02-2006", false},
 			{"01/02/2006", false},
 			{"01/02/06", false},
-
-			// The ordering of SGNLUnixMilli and SGNLUnixSec is important.
-			{SGNLUnixMilli, false}, // Unix timestamp representing milliseconds since 1970-01-01 00:00:00 UTC.
-			{SGNLUnixSec, false},   // Unix timestamp representing seconds since 1970-01-01 00:00:00 UTC.
-
+			{SGNLUnixSec, false},        // Unix timestamp representing seconds since 1970-01-01 00:00:00 UTC.
 			{SGNLGeneralizedTime, true}, // https://datatracker.ietf.org/doc/html/rfc4517#section-3.3.13  Generalized Time
 		},
 		enableJSONPath:      false, // Disabled.

--- a/web/json_options.go
+++ b/web/json_options.go
@@ -137,6 +137,8 @@ func WithComplexAttributeNameDelimiter(delimiter string) JSONOption {
 // attribute values from strings.
 // The formats must be ordered by decreasing likelihood of matching.
 // Each format must be a valid time format accepted by time.Parse.
+// Note: Adding both SGNLUnixSec and SGNLUnixMilli to formats is not recommended. Any valid numerical value can be
+// parsed by both formats. The output would depend on the ordering of the format thereby yielding undesired results.
 func WithDateTimeFormats(formats ...DateTimeFormatWithTimeZone) JSONOption {
 	return &funcJSONOption{
 		f: func(jo *jsonOptions) {

--- a/web/json_options.go
+++ b/web/json_options.go
@@ -55,6 +55,7 @@ type DateTimeFormatWithTimeZone struct {
 }
 
 const (
+	SGNLUnixMilli       = "SGNLUnixMilli"
 	SGNLUnixSec         = "SGNLUnixSec"
 	SGNLGeneralizedTime = "SGNLGeneralizedTime"
 )
@@ -80,7 +81,11 @@ func defaultJSONOptions() *jsonOptions {
 			{"01-02-2006", false},
 			{"01/02/2006", false},
 			{"01/02/06", false},
-			{SGNLUnixSec, false},        // Unix timestamp representing seconds since 1970-01-01 00:00:00 UTC.
+
+			// The ordering of SGNLUnixMilli and SGNLUnixSec is important.
+			{SGNLUnixMilli, false}, // Unix timestamp representing milliseconds since 1970-01-01 00:00:00 UTC.
+			{SGNLUnixSec, false},   // Unix timestamp representing seconds since 1970-01-01 00:00:00 UTC.
+
 			{SGNLGeneralizedTime, true}, // https://datatracker.ietf.org/doc/html/rfc4517#section-3.3.13  Generalized Time
 		},
 		enableJSONPath:      false, // Disabled.

--- a/web/json_value.go
+++ b/web/json_value.go
@@ -186,15 +186,22 @@ func convertJSONAttributeListValue[Element any](attribute *framework.AttributeCo
 // ParseDateTime parses a timestamp against a set of predefined formats.
 func ParseDateTime(dateTimeFormats []DateTimeFormatWithTimeZone, localTimeZoneOffset int, dateTimeStr string) (dateTime time.Time, err error) {
 	for _, format := range dateTimeFormats {
-		if format.Format == "SGNLUnixSec" {
+		switch format.Format {
+		case SGNLUnixMilli:
+			var unixTimestamp int64
+			unixTimestamp, err = strconv.ParseInt(dateTimeStr, 10, 64)
+			if err == nil {
+				dateTime = time.UnixMilli(unixTimestamp)
+			}
+		case SGNLUnixSec:
 			var unixTimestamp int64
 			unixTimestamp, err = strconv.ParseInt(dateTimeStr, 10, 64)
 			if err == nil {
 				dateTime = time.Unix(unixTimestamp, 0)
 			}
-		} else if format.Format == SGNLGeneralizedTime {
+		case SGNLGeneralizedTime:
 			dateTime, err = ber.ParseGeneralizedTime([]byte(dateTimeStr))
-		} else {
+		default:
 			dateTime, err = time.Parse(format.Format, dateTimeStr)
 		}
 

--- a/web/json_value_test.go
+++ b/web/json_value_test.go
@@ -88,17 +88,106 @@ func TestConvertJSONAttributeValue(t *testing.T) {
 			valueJSON: `[true, 0, "true"]`,
 			wantValue: []bool{true, false, true},
 		},
-		"unix": {
+		"unix_milli": {
+			attribute: &framework.AttributeConfig{
+				ExternalId: "a",
+				Type:       framework.AttributeTypeDateTime,
+			},
+			valueJSON: `1706041056000`,
+
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{SGNLUnixMilli, false}}},
+			wantValue: MustParseTime(t, "2024-01-23T20:17:36Z"),
+		},
+		"valid_unix_milli_missing_option": {
+			attribute: &framework.AttributeConfig{
+				ExternalId: "a",
+				Type:       framework.AttributeTypeDateTime,
+			},
+			valueJSON: `1706041056000`,
+
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{time.RFC3339, true}}},
+			wantError: errors.New("attribute a cannot be parsed into a date-time value: failed to parse date-time value: 1706041056000"),
+		},
+		"unix_milli_prefixed_with_+": {
+			attribute: &framework.AttributeConfig{
+				ExternalId: "a",
+				Type:       framework.AttributeTypeDateTime,
+			},
+			valueJSON: `"+1706041056000"`,
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{SGNLUnixMilli, false}}},
+			wantValue: MustParseTime(t, "2024-01-23T20:17:36Z"),
+		},
+		"invalid_unix_milli_timestamp": {
+			attribute: &framework.AttributeConfig{
+				ExternalId: "a",
+				Type:       framework.AttributeTypeDateTime,
+			},
+			valueJSON: `"17060invalid6"`,
+
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{SGNLUnixMilli, false}}},
+			wantError: errors.New("attribute a cannot be parsed into a date-time value: failed to parse date-time value: 17060invalid6"),
+		},
+		"invalid_float_unix_milli_timestamp": {
+			attribute: &framework.AttributeConfig{
+				ExternalId: "a",
+				Type:       framework.AttributeTypeDateTime,
+			},
+			valueJSON: `1706041056.005`,
+
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{SGNLUnixMilli, false}}},
+			wantError: errors.New("attribute a cannot be parsed into a date-time because the value is not an integer"),
+		},
+		"unix_milli_timestamp_int64_overflow": {
+			attribute: &framework.AttributeConfig{
+				ExternalId: "a",
+				Type:       framework.AttributeTypeDateTime,
+			},
+			valueJSON: `9999999999999999999999999999999999999999`,
+
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{SGNLUnixMilli, false}}},
+			wantError: errors.New("attribute a cannot be parsed into a date-time value as the value is out of the valid range"),
+		},
+		"neg_unix_milli": {
+			attribute: &framework.AttributeConfig{
+				ExternalId: "a",
+				Type:       framework.AttributeTypeDateTime,
+			},
+			valueJSON: `-1706041056000`,
+
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{SGNLUnixMilli, false}}},
+			wantValue: MustParseTime(t, "1915-12-10T03:42:24Z"),
+		},
+		"unix_milli_with_local_timezone_offset": {
+			attribute: &framework.AttributeConfig{
+				ExternalId: "a",
+				Type:       framework.AttributeTypeDateTime,
+			},
+			valueJSON: `1706041056000`,
+
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{SGNLUnixMilli, false}}, localTimeZoneOffset: 10 * 60 * 60},
+			wantValue: MustParseTime(t, "2024-01-23T20:17:36+10:00"),
+		},
+		"unix_milli_with_negative_time_zone_offset": {
+			attribute: &framework.AttributeConfig{
+				ExternalId: "a",
+				Type:       framework.AttributeTypeDateTime,
+			},
+			valueJSON: `1706041056000`,
+
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{SGNLUnixMilli, false}}, localTimeZoneOffset: -10 * 60 * 60},
+			wantValue: MustParseTime(t, "2024-01-23T20:17:36-10:00"),
+		},
+		"unix_sec": {
 			attribute: &framework.AttributeConfig{
 				ExternalId: "a",
 				Type:       framework.AttributeTypeDateTime,
 			},
 			valueJSON: `1706041056`,
 
-			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"SGNLUnixSec", false}}},
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{SGNLUnixSec, false}}},
 			wantValue: MustParseTime(t, "2024-01-23T20:17:36Z"),
 		},
-		"valid_unix_missing_option": {
+		"valid_unix_sec_missing_option": {
 			attribute: &framework.AttributeConfig{
 				ExternalId: "a",
 				Type:       framework.AttributeTypeDateTime,
@@ -108,73 +197,73 @@ func TestConvertJSONAttributeValue(t *testing.T) {
 			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{time.RFC3339, true}}},
 			wantError: errors.New("attribute a cannot be parsed into a date-time value: failed to parse date-time value: 1706041056"),
 		},
-		"unix_prefixed_with_+": {
+		"unix_sec_prefixed_with_+": {
 			attribute: &framework.AttributeConfig{
 				ExternalId: "a",
 				Type:       framework.AttributeTypeDateTime,
 			},
 			valueJSON: `"+1706041056"`,
-			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"SGNLUnixSec", false}}},
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{SGNLUnixSec, false}}},
 			wantValue: MustParseTime(t, "2024-01-23T20:17:36Z"),
 		},
-		"invalid_unix_timestamp": {
+		"invalid_unix_sec_timestamp": {
 			attribute: &framework.AttributeConfig{
 				ExternalId: "a",
 				Type:       framework.AttributeTypeDateTime,
 			},
 			valueJSON: `"17060invalid6"`,
 
-			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"SGNLUnixSec", false}}},
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{SGNLUnixSec, false}}},
 			wantError: errors.New("attribute a cannot be parsed into a date-time value: failed to parse date-time value: 17060invalid6"),
 		},
-		"invalid_float_unix_timestamp": {
+		"invalid_float_unix_sec_timestamp": {
 			attribute: &framework.AttributeConfig{
 				ExternalId: "a",
 				Type:       framework.AttributeTypeDateTime,
 			},
 			valueJSON: `1706041056.005`,
 
-			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"SGNLUnixSec", false}}},
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{SGNLUnixSec, false}}},
 			wantError: errors.New("attribute a cannot be parsed into a date-time because the value is not an integer"),
 		},
-		"unix_timestamp_int64_overflow": {
+		"unix_sec_timestamp_int64_overflow": {
 			attribute: &framework.AttributeConfig{
 				ExternalId: "a",
 				Type:       framework.AttributeTypeDateTime,
 			},
 			valueJSON: `9999999999999999999999999999999999999999`,
 
-			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"SGNLUnixSec", false}}},
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{SGNLUnixSec, false}}},
 			wantError: errors.New("attribute a cannot be parsed into a date-time value as the value is out of the valid range"),
 		},
-		"neg_unix": {
+		"neg_unix_sec": {
 			attribute: &framework.AttributeConfig{
 				ExternalId: "a",
 				Type:       framework.AttributeTypeDateTime,
 			},
 			valueJSON: `-1706041056`,
 
-			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"SGNLUnixSec", false}}},
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{SGNLUnixSec, false}}},
 			wantValue: MustParseTime(t, "1915-12-10T03:42:24Z"),
 		},
-		"unix_with_local_timezone_offset": {
+		"unix_sec_with_local_timezone_offset": {
 			attribute: &framework.AttributeConfig{
 				ExternalId: "a",
 				Type:       framework.AttributeTypeDateTime,
 			},
 			valueJSON: `1706041056`,
 
-			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"SGNLUnixSec", false}}, localTimeZoneOffset: 10 * 60 * 60},
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{SGNLUnixSec, false}}, localTimeZoneOffset: 10 * 60 * 60},
 			wantValue: MustParseTime(t, "2024-01-23T20:17:36+10:00"),
 		},
-		"unix_with_negative_time_zone_offset": {
+		"unix_sec_with_negative_time_zone_offset": {
 			attribute: &framework.AttributeConfig{
 				ExternalId: "a",
 				Type:       framework.AttributeTypeDateTime,
 			},
 			valueJSON: `1706041056`,
 
-			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{"SGNLUnixSec", false}}, localTimeZoneOffset: -10 * 60 * 60},
+			opts:      &jsonOptions{dateTimeFormats: []DateTimeFormatWithTimeZone{{SGNLUnixSec, false}}, localTimeZoneOffset: -10 * 60 * 60},
 			wantValue: MustParseTime(t, "2024-01-23T20:17:36-10:00"),
 		},
 		"generalized_with_seconds_and_z": {


### PR DESCRIPTION
This PR adds support for parsing unix timestamp represented in milliseconds since `JAN 01 1970. (UTC)`