### PR TITLE
[sc-31248] Include the datasource `id` in an adapter request

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -36,6 +36,10 @@ type Adapter[Config any] interface {
 // The Config type parameter must be a struct type the configuration
 // JSON object can be unmarshaled into.
 type Request[Config any] struct {
+	// DatasourceID is the ID of the datasource.
+	// Required.
+	DatasourceID string `json:"datasourceID"`
+
 	// Config is configuration for the datasource.
 	// Optional.
 	Config *Config `json:"config,omitempty"`

--- a/server/internal/request.go
+++ b/server/internal/request.go
@@ -100,6 +100,7 @@ func getAdapterRequest[Config any](
 		return nil, nil, adapterErr
 	}
 
+	adapterRequest.DatasourceID = req.Datasource.Id
 	adapterRequest.Address = req.Datasource.Address
 	adapterRequest.Auth = getAdapterAuth(req.Datasource.Auth)
 	adapterRequest.Entity = *entityConfig

--- a/server/internal/request_test.go
+++ b/server/internal/request_test.go
@@ -225,6 +225,7 @@ func TestGetAdapterRequest(t *testing.T) {
 				Cursor:   "the cursor",
 			},
 			wantAdapterRequest: &framework.Request[TestConfigA]{
+				DatasourceID: "1f530a64-0565-49e6-8647-b88e908b7229",
 				Config: &TestConfigA{
 					A: "a value",
 					B: "b value",
@@ -280,6 +281,7 @@ func TestGetAdapterRequest(t *testing.T) {
 				PageSize: 100,
 			},
 			wantAdapterRequest: &framework.Request[TestConfigA]{
+				DatasourceID: "1f530a64-0565-49e6-8647-b88e908b7229",
 				Entity: framework.EntityConfig{
 					ExternalId: "users",
 					Attributes: []*framework.AttributeConfig{


### PR DESCRIPTION
Please see the [shortcut story](https://app.shortcut.com/sgnl/story/31248/extend-adapter-framework-to-include-id-field-on-an-adapter-request) for details.