### PR TITLE
[sc-45923] context for the on-prem connector info

### DIFF
--- a/pkg/connector/context.go
+++ b/pkg/connector/context.go
@@ -30,6 +30,9 @@ type key struct{}
 
 // FromContext returns the ConnectorInfo value stored in the ctx, if any.
 func FromContext(ctx context.Context) (v ConnectorInfo, ok bool) {
+	if ctx == nil {
+		panic("cannot create connector context from nil parent")
+	}
 	v, ok = ctx.Value(key{}).(ConnectorInfo)
 	return
 }

--- a/pkg/connector/context.go
+++ b/pkg/connector/context.go
@@ -1,0 +1,43 @@
+package connector
+
+import (
+	"context"
+	"fmt"
+)
+
+// SourceType identifies a particular source as a datasource or
+// an integration.
+type SourceType int
+
+const (
+	Unknown SourceType = iota
+	Datasource
+	Integration
+)
+
+// ConnectorInfo carries information about the on-premises connector,
+// such as its ID, and the source it belongs to, for communication purposes.
+type ConnectorInfo struct {
+	ID         string
+	ClientID   string
+	TenantID   string
+	SourceType SourceType
+	SourceID   string
+}
+
+// key for storing the ConnectorInfo in a derived context.
+type key struct{}
+
+// FromContext returns the ConnectorInfo value stored in the ctx, if any.
+func FromContext(ctx context.Context) (v ConnectorInfo, ok bool) {
+	v, ok = ctx.Value(key{}).(ConnectorInfo)
+	return
+}
+
+// WithContext returns a derived ctx with the ConnectorInfo value stored in it.
+func WithContext(parent context.Context, val ConnectorInfo) (context.Context, error) {
+	if v, ok := FromContext(parent); ok {
+		return nil, fmt.Errorf("context is already configured with the connector info, %v", v)
+	}
+	return context.WithValue(parent, key{}, val), nil
+}

--- a/pkg/connector/context.go
+++ b/pkg/connector/context.go
@@ -31,7 +31,7 @@ type key struct{}
 // FromContext returns the ConnectorInfo value stored in the ctx, if any.
 func FromContext(ctx context.Context) (v ConnectorInfo, ok bool) {
 	if ctx == nil {
-		panic("cannot create connector context from nil parent")
+		panic("cannot read connector info value from nil context")
 	}
 	v, ok = ctx.Value(key{}).(ConnectorInfo)
 	return

--- a/pkg/connector/context_test.go
+++ b/pkg/connector/context_test.go
@@ -1,0 +1,96 @@
+package connector
+
+import (
+	"context"
+	"testing"
+)
+
+func TestFromContext(t *testing.T) {
+	tests := []struct {
+		name    string
+		ctx     context.Context
+		wantVal ConnectorInfo
+		wantOk  bool
+	}{
+		{
+			name:    "empty context returns false",
+			ctx:     context.Background(),
+			wantVal: ConnectorInfo{},
+			wantOk:  false,
+		},
+		{
+			name: "context with value returns true",
+			ctx: context.WithValue(context.Background(), key{}, ConnectorInfo{
+				ID: "test-id",
+			}),
+			wantVal: ConnectorInfo{ID: "test-id"},
+			wantOk:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotVal, gotOk := FromContext(tt.ctx)
+			if gotOk != tt.wantOk {
+				t.Errorf("FromContext() ok = %v, want %v", gotOk, tt.wantOk)
+			}
+			if gotVal != tt.wantVal {
+				t.Errorf("FromContext() val = %v, want %v", gotVal, tt.wantVal)
+			}
+		})
+	}
+}
+
+func TestWithContext(t *testing.T) {
+	tests := []struct {
+		name        string
+		parent      context.Context
+		val         ConnectorInfo
+		wantErr     bool
+		wantErrText string
+	}{
+		{
+			name:    "successfully add context info",
+			parent:  context.Background(),
+			val:     ConnectorInfo{ID: "test-id"},
+			wantErr: false,
+		},
+		{
+			name:        "error when context already has value",
+			parent:      context.WithValue(context.Background(), key{}, ConnectorInfo{ID: "existing-id"}),
+			val:         ConnectorInfo{ID: "new-id"},
+			wantErr:     true,
+			wantErrText: "context is already configured",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, err := WithContext(tt.parent, tt.val)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("WithContext() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				if err == nil || !contains(err.Error(), tt.wantErrText) {
+					t.Errorf("WithContext() error = %v, want error containing %v", err, tt.wantErrText)
+				}
+				return
+			}
+
+			// Verify the context value was set correctly
+			gotVal, ok := FromContext(ctx)
+			if !ok {
+				t.Error("WithContext() value not found in context")
+			}
+			if gotVal != tt.val {
+				t.Errorf("WithContext() value = %v, want %v", gotVal, tt.val)
+			}
+		})
+	}
+}
+
+// Helper function to check if a string contains another string
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && s[:len(substr)] == substr
+}

--- a/pkg/connector/context_test.go
+++ b/pkg/connector/context_test.go
@@ -32,7 +32,7 @@ func TestFromContext(t *testing.T) {
 		{
 			name:         "nil context with value should panic",
 			wantPanic:    true,
-			wantPanicMsg: "cannot create connector context from nil parent",
+			wantPanicMsg: "cannot read connector info value from nil context",
 		},
 	}
 

--- a/pkg/connector/context_test.go
+++ b/pkg/connector/context_test.go
@@ -7,10 +7,12 @@ import (
 
 func TestFromContext(t *testing.T) {
 	tests := []struct {
-		name    string
-		ctx     context.Context
-		wantVal ConnectorInfo
-		wantOk  bool
+		name         string
+		ctx          context.Context
+		wantVal      ConnectorInfo
+		wantOk       bool
+		wantPanic    bool
+		wantPanicMsg string
 	}{
 		{
 			name:    "empty context returns false",
@@ -26,10 +28,24 @@ func TestFromContext(t *testing.T) {
 			wantVal: ConnectorInfo{ID: "test-id"},
 			wantOk:  true,
 		},
+		{
+			name:         "nil context with value should panic",
+			wantPanic:    true,
+			wantPanicMsg: "cannot create connector context from nil parent",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.wantPanic {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Errorf("Test didn't panic")
+					} else if r != tt.wantPanicMsg {
+						t.Errorf("Unexpected panic messages: got %v, want: %v", r, tt.wantPanicMsg)
+					}
+				}()
+			}
 			gotVal, gotOk := FromContext(tt.ctx)
 			if gotOk != tt.wantOk {
 				t.Errorf("FromContext() ok = %v, want %v", gotOk, tt.wantOk)

--- a/pkg/connector/context_test.go
+++ b/pkg/connector/context_test.go
@@ -2,6 +2,7 @@ package connector
 
 import (
 	"context"
+	"strings"
 	"testing"
 )
 
@@ -88,7 +89,7 @@ func TestWithContext(t *testing.T) {
 				return
 			}
 			if tt.wantErr {
-				if err == nil || !contains(err.Error(), tt.wantErrText) {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErrText) {
 					t.Errorf("WithContext() error = %v, want error containing %v", err, tt.wantErrText)
 				}
 				return
@@ -104,9 +105,4 @@ func TestWithContext(t *testing.T) {
 			}
 		})
 	}
-}
-
-// Helper function to check if a string contains another string
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && s[:len(substr)] == substr
 }


### PR DESCRIPTION
Context to pass connector metadata to the underlying transport client.
This context is going to be used by the transport client for communicating with on-premises connectors.