### PR TITLE
[sc-45922] Check for a configured proxy in the HTTP Client

### DIFF
--- a/pkg/connector/client/http.go
+++ b/pkg/connector/client/http.go
@@ -47,6 +47,11 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req = req.Clone(req.Context()) // According to RoundTripper spec, we shouldn't modify the original request.
 	req.Header.Set("User-Agent", t.userAgentHeader)
 
+	// Check if the transport has proxy configured.
+	if t.proxyClient == nil {
+		return t.rt.RoundTrip(req)
+	}
+
 	// Lookup Connector context for proxying the request.
 	// In case, context is not present the request is forward using default
 	// HTTP round-tripper.

--- a/pkg/connector/client/http_test.go
+++ b/pkg/connector/client/http_test.go
@@ -116,6 +116,36 @@ func TestGivenSGNLHTTPClientWithoutGRPCProxyThenSendRequestSentWithoutProxyAndRe
 	}
 }
 
+func TestGivenSGNLHTTPClientWithConnectorContextAndWithoutGRPCProxyThenSendRequestSentWithoutProxyAndReturnsStatusOK(t *testing.T) {
+	// Build
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	client := NewSGNLHTTPClientWithProxy(time.Second, "", nil)
+
+	ctx, err := connector.WithContext(context.Background(), connector.ConnectorInfo{})
+	if err != nil {
+		t.Fatalf("failed to create connector info context %v", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatalf("failed to create a http request, %v", err)
+	}
+
+	// Test
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Failed to send a request to the Test server using SGNL client, %v", err)
+	}
+
+	// Verify
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Test server failed to return StatusOK using SGNL client")
+	}
+}
+
 var GRPCTestServerResponse = "response from the grpc test server"
 
 type testServer struct {

--- a/pkg/connector/client/http_test.go
+++ b/pkg/connector/client/http_test.go
@@ -139,6 +139,7 @@ func TestGivenSGNLHTTPClientWithConnectorContextAndWithoutGRPCProxyThenSendReque
 	if err != nil {
 		t.Fatalf("Failed to send a request to the Test server using SGNL client, %v", err)
 	}
+	defer resp.Body.Close()
 
 	// Verify
 	if resp.StatusCode != http.StatusOK {


### PR DESCRIPTION
In order to allow the HTTP client to operate with or without a proxy, a check for a configured proxy is introduced in the HTTP transport.