### PR TITLE
[sc-58699] ignore nil child objects instead of the list assertion

### DIFF
--- a/web/json_object.go
+++ b/web/json_object.go
@@ -317,7 +317,9 @@ func convertJSONObject(entity *framework.EntityConfig, object map[string]any, op
 
 		if jsonPath, found := jsonPaths[externalId]; found { // The entity external ID is a JSONPath.
 			childObjectsRaw, err := jsonPath(context.Background(), object)
-			if err != nil { // The JSONPath didn't match. Evaluate to null.
+			// The JSONPath didn't match or if the object is nil. Evaluate to null.
+			if err != nil || childObjectsRaw == nil {
+
 				continue
 			}
 

--- a/web/json_object.go
+++ b/web/json_object.go
@@ -319,7 +319,6 @@ func convertJSONObject(entity *framework.EntityConfig, object map[string]any, op
 			childObjectsRaw, err := jsonPath(context.Background(), object)
 			// The JSONPath didn't match or if the object is nil. Evaluate to null.
 			if err != nil || childObjectsRaw == nil {
-
 				continue
 			}
 

--- a/web/json_object_test.go
+++ b/web/json_object_test.go
@@ -1238,6 +1238,58 @@ func TestConvertJSONObject_JSONPath(t *testing.T) {
 			wantObject: nil,
 			wantError:  errors.New("non-list attribute $.emails[*].value matched multiple values"),
 		},
+		"child_entities_jsonpath_returns_nil": {
+			entity: &framework.EntityConfig{
+				ExternalId: "test",
+				Attributes: []*framework.AttributeConfig{
+					{
+						ExternalId: "id",
+						Type:       framework.AttributeTypeString,
+					},
+				},
+				ChildEntities: []*framework.EntityConfig{
+					{
+						ExternalId: "$.nullChildren", // This JSONPath will return nil (no error)
+						Attributes: []*framework.AttributeConfig{
+							{
+								ExternalId: "name",
+								Type:       framework.AttributeTypeString,
+							},
+						},
+					},
+					{
+						ExternalId: "$.existing.children",
+						Attributes: []*framework.AttributeConfig{
+							{
+								ExternalId: "name",
+								Type:       framework.AttributeTypeString,
+							},
+						},
+					},
+				},
+			},
+			objectJSON: `{
+				"id": "test123",
+				"nullChildren": null,
+				"existing": {
+					"children": [
+						{
+							"name": "child1"
+						}
+					]
+				}
+			}`,
+			opts: testJSONOptions,
+			wantObject: framework.Object{
+				"id": "test123",
+				"$.existing.children": []framework.Object{
+					{
+						"name": "child1",
+					},
+				},
+			},
+			wantError: nil,
+		},
 	}
 
 	for name, tc := range tests {


### PR DESCRIPTION
While parsing and converting JSON objects, It's safe to ignore child objects that are nil when checking the JSON path, rather than failing a type assertion on a list value.
