### PR TITLE
Pin GitHub Actions to commit SHA

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,14 +24,14 @@ jobs:
     steps:
       - if: ${{ github.event_name == 'pull_request' }}
         name: Checkout repository (pull_request) ✅
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
 
       - if: ${{ github.event_name == 'push' }}
         name: Checkout repository (push) ✅
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Generate protobufs 🔧
         run: make proto
@@ -48,21 +48,21 @@ jobs:
     steps:
       - if: ${{ github.event_name == 'pull_request' }}
         name: Checkout repository (pull_request) ✅
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
 
       - if: ${{ github.event_name == 'push' }}
         name: Checkout repository (push) ✅
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       
       - name: Run tests and code coverage 🧪
         run: docker run --rm --network="host" -v ./:/src -w /src golang:1.26-bookworm go test -coverprofile=coverage.txt -covermode=atomic -v ./...
 
       # CodeCov
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
## Summary

Pin all third-party GitHub Actions to full-length commit SHAs for supply chain security.

## Changes

Actions are pinned to the exact commit matching the version tag. Version preserved as inline comment for readability.

## Context

- Jira: [PRODSEC-132424](https://jira.cs.sys/browse/PRODSEC-132424)
- Pinning reduces supply chain risk by ensuring exact action versions
- Version preserved as comment: `action@<sha> # <version>`

## Test plan

- [ ] Verify workflow syntax is valid (Actions tab shows no parse errors)
- [ ] Confirm pinned SHAs match expected versions

LLM Agent(s) contributed to this PR.