### PR TITLE
[CONTID-11148] Remove dependabot github-actions ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,10 +12,3 @@ updates:
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10
-    cooldown:
-      default-days: 7


### PR DESCRIPTION
Remove github-actions package ecosystem from Dependabot configuration.

GHA versions are explicitly allowlisted and AppSec will reach out when specific vulnerabilities need updates.

Jira: https://jira.cs.sys/browse/CONTID-11148

LLM Agent(s) contributed to this PR.